### PR TITLE
[Stand-by] AuthorizationLevel.Function instead of Anonymous

### DIFF
--- a/src/DotNetFunction/SampleHelloDotNetFunction.cs
+++ b/src/DotNetFunction/SampleHelloDotNetFunction.cs
@@ -9,7 +9,7 @@ namespace DotNetFunction
     public static class SampleHelloDotNetFunction
     {
         [FunctionName("SampleHelloDotNetFunction")]
-        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Anonymous, "get")]HttpRequestMessage request)
+        public static HttpResponseMessage Run([HttpTrigger(AuthorizationLevel.Function, "get")]HttpRequestMessage request)
         {
             var name = request.GetQueryNameValuePairs()
                 .FirstOrDefault(q => string.Compare(q.Key, "name", true) == 0)

--- a/test/DotNetFunction.IntegrationTests/SampleHelloDotNetFunctionTests.cs
+++ b/test/DotNetFunction.IntegrationTests/SampleHelloDotNetFunctionTests.cs
@@ -30,8 +30,7 @@ namespace DotNetFunction.IntegrationTests
             var response = await httpClient.GetAsync(urlTested);
 
             //Assert
-            //Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
-            Assert.Equal(HttpStatusCode.OK, response.StatusCode);//TMP: should be replaced by the line above when this issue will be fixed: https://github.com/Azure/azure-webjobs-sdk-script/issues/1752
+            Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
         }
 
         [Fact]


### PR DESCRIPTION
For more security, need to use the Azure Function Key throughout the automated CD pipeline.
**This PR is on stand-by** because there is currently an issue with the Slot feature on Azure Function:
https://github.com/Azure/azure-webjobs-sdk-script/issues/1752